### PR TITLE
Allow playing on demand items from the PVR Guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ Thumbs.db
 # IPTV Manager output
 tests/userdata/playlist.m3u8
 tests/userdata/epg.xml
+tests/userdata/channels.json

--- a/addon.xml
+++ b/addon.xml
@@ -5,7 +5,15 @@
         <import addon="script.module.dateutil" version="2.6.0"/>
     </requires>
     <extension point="xbmc.service" library="service.py"/>
-	<extension point="xbmc.python.library" library="default.py" />
+    <extension point="xbmc.python.library" library="default.py"/>
+    <extension point="kodi.context.item">
+        <menu id="kodi.core.main">
+            <item library="context.py">
+                <label>30600</label>
+                <visible>Window.IsVisible(tvguide)|Window.IsVisible(tvsearch)</visible>
+            </item>
+        </menu>
+    </extension>
     <extension point="xbmc.addon.metadata">
         <summary lang="en_GB">Integrate IPTV Channels from other Add-ons in the Kodi PVR</summary>
         <description lang="en_GB">This add-on integrates IPTV Channels from other Add-ons in the Kodi PVR.</description>

--- a/context.py
+++ b/context.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""This is the actual IPTV Manager context menu entry point"""
+
+from __future__ import absolute_import, division, unicode_literals
+
+from resources.lib.functions import run
+
+run([-1, 'play_from_contextmenu'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ polib
 pylint
 python-dateutil
 tox
+mock

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -5,6 +5,12 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+### CONTEXT MENU
+msgctxt "#30600"
+msgid "Play with IPTV Manager"
+msgstr ""
+
+
 ### MESSAGES
 msgctxt "#30700"
 msgid "Are you sure you want to setup IPTV Simple for the use with IPTV Manager? Any existing configuration of IPTV Simple will be overwritten."
@@ -32,6 +38,18 @@ msgstr ""
 
 msgctxt "#30706"
 msgid "The channels and guide are updated successfully!"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Could not find an Add-on to play programs from {channel}"
+msgstr ""
+
+msgctxt "#30711"
+msgid "Select an Add-on to use for playback"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Could not determine the currently selected program. Please try again without selecting another program."
 msgstr ""
 
 

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -6,6 +6,12 @@ msgstr ""
 "Language: nl\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+### CONTEXT MENU
+msgctxt "#30600"
+msgid "Play with IPTV Manager"
+msgstr "Afspelen met IPTV Manager"
+
+
 ### MESSAGES
 msgctxt "#30700"
 msgid "Are you sure you want to setup IPTV Simple for the use with IPTV Manager? Any existing configuration of IPTV Simple will be overwritten."
@@ -34,6 +40,19 @@ msgstr "Updaten van de kanalenlijst en de gids..."
 msgctxt "#30706"
 msgid "The channels and guide are updated successfully!"
 msgstr "De kanalenlijst en gids zijn sucessvol geüpdate."
+
+msgctxt "#30710"
+msgid "Could not find an Add-on to play programs from {channel}"
+msgstr "Kon geen Add-on vinden om programma's van {channel} af te spelen"
+
+msgctxt "#30711"
+msgid "Select an Add-on to use for playback"
+msgstr "Selecteer een Add-on om te gebruiken voor het afspelen"
+
+msgctxt "#30712"
+msgid "Could not determine the currently selected program. Please try again without selecting another program."
+msgstr "Kon het geselecteerde programma niet bepalen. Probeer opnieuw zonder een andere programma te selecteren."
+
 
 
 ### SETTINGS

--- a/resources/lib/functions.py
+++ b/resources/lib/functions.py
@@ -7,6 +7,7 @@ import logging
 
 from resources.lib import kodilogging, kodiutils
 from resources.lib.modules.addon import Addon
+from resources.lib.modules.contextmenu import ContextMenu
 from resources.lib.modules.iptvsimple import IptvSimple
 
 kodilogging.config()
@@ -34,17 +35,26 @@ def refresh():
     kodiutils.open_settings()
 
 
+def play_from_contextmenu():
+    """ Play an item from the Context Menu """
+    # Fetch selection from Kodi
+    program = ContextMenu.get_selection()
+    if program:
+        ContextMenu.play(program)
+
+
 def run(args):
     """ Run the function """
     function = args[1]
     function_map = {
         'setup-iptv-simple': setup_iptv_simple,
         'refresh': refresh,
+        'play_from_contextmenu': play_from_contextmenu,
     }
     try:
         # TODO: allow to pass *args to the function so we can also pass arguments
         _LOGGER.debug('Routing to function: %s', function)
         function_map.get(function)()
-    except TypeError:
+    except (TypeError, IndexError):
         _LOGGER.error('Could not route to %s', function)
         raise

--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -358,3 +358,8 @@ def get_addon(name):
 def get_info_label(label):
     """Returns a InfoLabel from Kodi"""
     return xbmc.getInfoLabel(label)
+
+
+def get_region(key):
+    """Returns Region information from Kodi"""
+    return xbmc.getRegion(key)

--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -109,6 +109,14 @@ def notification(heading='', message='', icon='info', time=4000):
     Dialog().notification(heading=heading, message=message, icon=icon, time=time)
 
 
+def select(heading='', options=None, autoclose=0, preselect=-1, use_details=False):
+    """Show a Kodi select dialog"""
+    from xbmcgui import Dialog
+    if not heading:
+        heading = addon_name()
+    return Dialog().select(heading, options, autoclose=autoclose, preselect=preselect, useDetails=use_details)
+
+
 def multiselect(heading='', options=None, autoclose=0, preselect=None, use_details=False):
     """Show a Kodi multi-select dialog"""
     from xbmcgui import Dialog
@@ -345,3 +353,8 @@ def execute_builtin(command, *args):
 def get_addon(name):
     """Return an instance of the specified Addon"""
     return xbmcaddon.Addon(name)
+
+
+def get_info_label(label):
+    """Returns a InfoLabel from Kodi"""
+    return xbmc.getInfoLabel(label)

--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -346,7 +346,6 @@ def jsonrpc(*args, **kwargs):
 
 def execute_builtin(command, *args):
     """Execute a Kodi builtin function"""
-    _LOGGER.debug('Execute: %s(%s)', command, ",".join(args))
     xbmc.executebuiltin('{command}({params})'.format(command=command, params=",".join(args)))
 
 

--- a/resources/lib/modules/contextmenu.py
+++ b/resources/lib/modules/contextmenu.py
@@ -118,14 +118,14 @@ class ContextMenu:
     def write_channels(channels):
         """Write the channel data to a file."""
         channels_path = os.path.join(kodiutils.addon_profile(), CHANNELS_CACHE)
-        with open(channels_path, 'wb') as fdesc:
+        with open(channels_path, 'w') as fdesc:
             json.dump(channels, fdesc)
 
     @staticmethod
     def _get_addons_for_channel(channel):
         """Returns a list of Add-ons that can play this channel."""
         channels_path = os.path.join(kodiutils.addon_profile(), CHANNELS_CACHE)
-        with open(channels_path, 'rb') as fdesc:
+        with open(channels_path, 'r') as fdesc:
             data = json.load(fdesc)
 
         matches = {}

--- a/resources/lib/modules/contextmenu.py
+++ b/resources/lib/modules/contextmenu.py
@@ -38,21 +38,21 @@ class ContextMenu:
             kodiutils.notification(message=kodiutils.localize(30710, channel=program.get('channel')))  # Could not find an Add-on...
             return
 
-        elif len(addons) == 1:
+        if len(addons) == 1:
             # Channel has one Add-on. Play it directly.
             _LOGGER.debug('One Add-on was found to play %s: %s', program.get('channel'), addons)
             cls._play(addons.values()[0], program)
+            return
 
-        else:
-            # Ask the user to pick an Add-on
-            _LOGGER.debug('Multiple Add-on were found to play %s: %s', program.get('channel'), addons)
-            addons_list = list(addons)
-            ret = kodiutils.select(heading=kodiutils.localize(30711), options=addons_list)  # Select an Add-on...
-            if ret == -1:
-                _LOGGER.debug('The selection to play an item from %s was canceled', program.get('channel'))
-                return
+        # Ask the user to pick an Add-on
+        _LOGGER.debug('Multiple Add-on were found to play %s: %s', program.get('channel'), addons)
+        addons_list = list(addons)
+        ret = kodiutils.select(heading=kodiutils.localize(30711), options=addons_list)  # Select an Add-on...
+        if ret == -1:
+            _LOGGER.debug('The selection to play an item from %s was canceled', program.get('channel'))
+            return
 
-            cls._play(addons.get(addons_list[ret]), program)
+        cls._play(addons.get(addons_list[ret]), program)
 
     @classmethod
     def _play(cls, uri, program):

--- a/resources/lib/modules/contextmenu.py
+++ b/resources/lib/modules/contextmenu.py
@@ -1,0 +1,213 @@
+# -*- coding: utf-8 -*-
+""" Addon Module """
+
+from __future__ import absolute_import, division, unicode_literals
+
+import json
+import logging
+import os
+import sys
+import time
+from datetime import datetime
+
+from resources.lib import kodiutils
+
+_LOGGER = logging.getLogger(__name__)
+
+CHANNELS_CACHE = 'channels.json'
+
+
+class ContextMenu:
+    """Helper class for PVR Context Menu handling"""
+
+    def __init__(self):
+        """Initialise the Context Menu Module"""
+
+    @classmethod
+    def play(cls, program):
+        """Play the selected program."""
+        _LOGGER.debug('Playing %s', program)
+
+        # Get a list of addons that can play the selected channel
+        # We do the lookup based on Channel Name, since that's all we have
+        addons = cls._get_addons_for_channel(program.get('channel'))
+
+        if not addons:
+            # Channel was not found.
+            _LOGGER.debug('No Add-on was found to play %s', program.get('channel'))
+            kodiutils.notification(message=kodiutils.localize(30710, channel=program.get('channel')))  # Could not find an Add-on...
+            return
+
+        elif len(addons) == 1:
+            # Channel has one Add-on. Play it directly.
+            _LOGGER.debug('One Add-on was found to play %s: %s', program.get('channel'), addons)
+            cls._play(addons.values()[0], program)
+
+        else:
+            # Ask the user to pick an Add-on
+            _LOGGER.debug('Multiple Add-on were found to play %s: %s', program.get('channel'), addons)
+            addons_list = list(addons)
+            ret = kodiutils.select(heading=kodiutils.localize(30711), options=addons_list)  # Select an Add-on...
+            if ret == -1:
+                _LOGGER.debug('The selection to play an item from %s was canceled', program.get('channel'))
+                return
+
+            cls._play(addons.get(addons_list[ret]), program)
+
+    @classmethod
+    def _play(cls, uri, program):
+        """Play the selected program with the specified URI."""
+        if '{date}' in uri:
+            uri = uri.format(date=program.get('start').isoformat())
+
+        if '{duration}' in uri:
+            uri = uri.format(date=program.get('duration').isoformat())
+
+        _LOGGER.debug('Playing "%s"', uri)
+        kodiutils.execute_builtin('PlayMedia', uri)
+
+    @classmethod
+    def get_selection(cls):
+        """Retrieve information about the selected ListItem."""
+
+        # The selected ListItem should be in sys.listitem, but I could not find real data in there that we can use for EPG selections.
+        # Therefore, we use xbmc.getInfoLabel(ListItem.xxx), but that references the currently selected ListItem. This could not be the same as the
+        # item where the Context Menu was opened on, when the selection was moved really quick before the Python code was started.
+        # It seems I'm not alone in this: https://forum.kodi.tv/showthread.php?tid=294357
+
+        # cls._debug_get_selection()
+
+        # Check if the selected item is also the intended item
+        if sys.listitem.getPath() != kodiutils.get_info_label('ListItem.FolderPath'):  # pylint: disable=no-member
+            # We are in trouble. We know that the data we want to use is invalid, but there is nothing we can do.
+            kodiutils.ok_dialog(message=kodiutils.localize(30712))  # Could not determine the selected program...
+            return None
+
+        # Load information from the ListItem
+        date = kodiutils.get_info_label('ListItem.Date')
+        duration = kodiutils.get_info_label('ListItem.Duration')
+        channel = kodiutils.to_unicode(kodiutils.get_info_label('ListItem.ChannelName'))
+
+        # Parse begin to a datetime
+        try:
+            start = datetime.strptime(date, '%d-%m-%Y %H:%M')
+        except TypeError:
+            start = datetime(*(time.strptime(date, '%d-%m-%Y %H:%M')[0:6]))
+
+        # Parse duration to seconds
+        splitted = duration.split(':')
+        if len(splitted) == 1:  # %S
+            seconds = int(splitted[0])
+
+        elif len(splitted) == 2:  # %M:%S
+            seconds = int(splitted[0]) * 60 + int(splitted[1])
+
+        elif len(splitted) == 3:  # %H:%M:%S
+            seconds = int(splitted[0]) * 3600 + int(splitted[1]) * 60 + int(splitted[2])
+
+        else:
+            raise Exception('Unknown duration %s' % duration)
+
+        return dict(
+            start=start,
+            duration=seconds,
+            channel=channel,
+        )
+
+    @staticmethod
+    def write_channels(channels):
+        """Write the channel data to a file."""
+        channels_path = os.path.join(kodiutils.addon_profile(), CHANNELS_CACHE)
+        with open(channels_path, 'wb') as fdesc:
+            json.dump(channels, fdesc)
+
+    @staticmethod
+    def _get_addons_for_channel(channel):
+        """Returns a list of Add-ons that can play this channel."""
+        channels_path = os.path.join(kodiutils.addon_profile(), CHANNELS_CACHE)
+        with open(channels_path, 'rb') as fdesc:
+            data = json.load(fdesc)
+
+        matches = {}
+        for _addon in data:
+            for _channel in _addon.get('channels', []):
+                if _channel.get('name').lower() == channel.lower() and _channel.get('vod') is not None:
+                    matches.update({_addon.get('addon_name'): _channel.get('vod')})
+
+        return matches
+
+    @staticmethod
+    def _debug_get_selection():
+        """Return debugging data for getting the current ListItem"""
+        sys_listitem = sys.listitem  # pylint: disable=no-member
+        # Show the data we can get from sys_listitem. This is the item where the context menu was opened on.
+        _LOGGER.debug('sys.listitem.getLabel() = %s', sys_listitem.getLabel())
+        _LOGGER.debug('sys.listitem.getLabel2() = %s', sys_listitem.getLabel2())
+        _LOGGER.debug('sys.listitem.getfilename() = %s', sys_listitem.getfilename())  # inconsistent case
+        _LOGGER.debug('sys.listitem.getPath() = %s', sys_listitem.getPath())
+        _LOGGER.debug('sys.listitem.getArt("thumb") = %s', sys_listitem.getArt('thumb'))
+        _LOGGER.debug('sys.listitem.getArt("poster") = %s', sys_listitem.getArt('poster'))
+        _LOGGER.debug('sys.listitem.getArt("banner") = %s', sys_listitem.getArt('banner'))
+        _LOGGER.debug('sys.listitem.getArt("fanart") = %s', sys_listitem.getArt('fanart'))
+        _LOGGER.debug('sys.listitem.getArt("clearart") = %s', sys_listitem.getArt('clearart'))
+        _LOGGER.debug('sys.listitem.getArt("clearlogo") = %s', sys_listitem.getArt('clearlogo'))
+        _LOGGER.debug('sys.listitem.getArt("landscape") = %s', sys_listitem.getArt('landscape'))
+        _LOGGER.debug('sys.listitem.getArt("icon") = %s', sys_listitem.getArt('icon'))
+        _LOGGER.debug('sys.listitem.isSelected() = %s', sys_listitem.isSelected())
+
+        for prop in ['id', 'dbid', 'AspectRatio', 'Date', 'fanart_image']:
+            _LOGGER.debug('sys.listitem.getProperty("%s") = %s', prop, sys_listitem.getProperty(prop))
+
+        _LOGGER.debug('sys.listitem.getVideoInfoTag().getCast() = %s', sys_listitem.getVideoInfoTag().getCast())
+        _LOGGER.debug('sys.listitem.getVideoInfoTag().getDbId() = %s', sys_listitem.getVideoInfoTag().getDbId())
+        _LOGGER.debug('sys.listitem.getVideoInfoTag().getDirector() = %s', sys_listitem.getVideoInfoTag().getDirector())
+        _LOGGER.debug('sys.listitem.getVideoInfoTag().getFile() = %s', sys_listitem.getVideoInfoTag().getFile())
+        _LOGGER.debug('sys.listitem.getVideoInfoTag().getFirstAired() = %s', sys_listitem.getVideoInfoTag().getFirstAired())
+        _LOGGER.debug('sys.listitem.getVideoInfoTag().getIMDBNumber() = %s', sys_listitem.getVideoInfoTag().getIMDBNumber())
+        _LOGGER.debug('sys.listitem.getVideoInfoTag().getLastPlayed() = %s', sys_listitem.getVideoInfoTag().getLastPlayed())
+        _LOGGER.debug('sys.listitem.getVideoInfoTag().getMediaType() = %s', sys_listitem.getVideoInfoTag().getMediaType())
+        _LOGGER.debug('sys.listitem.getVideoInfoTag().getOriginalTitle() = %s', sys_listitem.getVideoInfoTag().getOriginalTitle())
+        _LOGGER.debug('sys.listitem.getVideoInfoTag().getPath() = %s', sys_listitem.getVideoInfoTag().getPath())
+        _LOGGER.debug('sys.listitem.getVideoInfoTag().getPictureURL() = %s', sys_listitem.getVideoInfoTag().getPictureURL())
+        _LOGGER.debug('sys.listitem.getVideoInfoTag().getPlayCount() = %s', sys_listitem.getVideoInfoTag().getPlayCount())
+        _LOGGER.debug('sys.listitem.getVideoInfoTag().getPlot() = %s', sys_listitem.getVideoInfoTag().getPlot())
+        _LOGGER.debug('sys.listitem.getVideoInfoTag().getPlotOutline() = %s', sys_listitem.getVideoInfoTag().getPlotOutline())
+        _LOGGER.debug('sys.listitem.getVideoInfoTag().getPremiered() = %s', sys_listitem.getVideoInfoTag().getPremiered())
+        _LOGGER.debug('sys.listitem.getVideoInfoTag().getRating() = %s', sys_listitem.getVideoInfoTag().getRating())
+        _LOGGER.debug('sys.listitem.getVideoInfoTag().getTagLine() = %s', sys_listitem.getVideoInfoTag().getTagLine())
+        _LOGGER.debug('sys.listitem.getVideoInfoTag().getTitle() = %s', sys_listitem.getVideoInfoTag().getTitle())
+        _LOGGER.debug('sys.listitem.getVideoInfoTag().getTVShowTitle() = %s', sys_listitem.getVideoInfoTag().getTVShowTitle())
+        _LOGGER.debug('sys.listitem.getVideoInfoTag().getVotes() = %s', sys_listitem.getVideoInfoTag().getVotes())
+        _LOGGER.debug('sys.listitem.getVideoInfoTag().getYear() = %s', sys_listitem.getVideoInfoTag().getYear())
+
+        # Show the data we can get from xmbc.getInfoLabel.  This is the item that is currently focused.
+        items = [
+            'ListItem.Thumb',
+            'ListItem.Icon',
+            'ListItem.Overlay',
+            'ListItem.Tag',
+            'ListItem.HasEPG',
+            'ListItem.HasArchive',
+            'ListItem.EpgEventTitle',
+            'ListItem.EpgEventIcon',
+            'ListItem.ChannelName',
+            'ListItem.ChannelGroup',
+            'ListItem.ChannelNumberLabel',
+            'ListItem.Date',
+            'ListItem.Duration',
+            'ListItem.EndDate',
+            'ListItem.EndTime',
+            'ListItem.EpisodeName',
+            'ListItem.FileName',
+            'ListItem.FolderPath',
+            'ListItem.Genre',
+            'ListItem.Label',
+            'ListItem.Path',
+            'ListItem.Plot',
+            'ListItem.PlotOutline',
+            'ListItem.StartDate',
+            'ListItem.StartTime',
+            'ListItem.Title',
+        ]
+        for item in items:
+            _LOGGER.debug('xmbc.getInfoLabel("%s") = %s', item, kodiutils.to_unicode(kodiutils.get_info_label(item)))

--- a/resources/lib/modules/contextmenu.py
+++ b/resources/lib/modules/contextmenu.py
@@ -89,10 +89,11 @@ class ContextMenu:
         channel = kodiutils.to_unicode(kodiutils.get_info_label('ListItem.ChannelName'))
 
         # Parse begin to a datetime
+        date_format = kodiutils.get_region('dateshort')
         try:
-            start = datetime.strptime(date, '%d-%m-%Y %H:%M')
+            start = datetime.strptime(date, date_format + ' %H:%M')
         except TypeError:
-            start = datetime(*(time.strptime(date, '%d-%m-%Y %H:%M')[0:6]))
+            start = datetime(*(time.strptime(date, date_format + ' %H:%M')[0:6]))
 
         # Parse duration to seconds
         splitted = duration.split(':')

--- a/resources/lib/modules/iptvsimple.py
+++ b/resources/lib/modules/iptvsimple.py
@@ -152,11 +152,14 @@ class IptvSimple:
                 for item in epg[key]:
                     start = dateutil.parser.parse(item.get('start')).strftime('%Y%m%d%H%M%S %z')
                     stop = dateutil.parser.parse(item.get('stop')).strftime('%Y%m%d%H%M%S %z')
+                    title = item.get('title')
+                    if not item.get('available', True):
+                        title = '[I]' + title + '[/I]'
 
                     fdesc.write('<programme start="{start}" stop="{stop}" channel="{channel}">\n'.format(start=start,
                                                                                                          stop=stop,
                                                                                                          channel=cls._xml_encode(key)).encode('utf8'))
-                    fdesc.write(' <title>{title}</title>\n'.format(title=cls._xml_encode(item.get('title'))).encode('utf-8'))
+                    fdesc.write(' <title>{title}</title>\n'.format(title=cls._xml_encode(title)).encode('utf-8'))
                     if item.get('description'):
                         fdesc.write(' <desc>{description}</desc>\n'.format(description=cls._xml_encode(item.get('description'))).encode('utf-8'))
                     if item.get('subtitle'):

--- a/resources/lib/modules/iptvsimple.py
+++ b/resources/lib/modules/iptvsimple.py
@@ -95,25 +95,28 @@ class IptvSimple:
         if not os.path.exists(output_dir):
             os.mkdir(output_dir)
 
+        # Write playlist for IPTV Simple
         playlist_path = os.path.join(output_dir, IPTV_SIMPLE_PLAYLIST)
 
         with open(playlist_path + '.tmp', 'wb') as fdesc:
             m3u8_data = '#EXTM3U\n'
 
-            for channel in channels:
-                m3u8_data += '#EXTINF:-1 tvg-name="{name}"'.format(**channel)
-                if channel.get('id'):
-                    m3u8_data += ' tvg-id="{id}"'.format(**channel)
-                if channel.get('logo'):
-                    m3u8_data += ' tvg-logo="{logo}"'.format(**channel)
-                if channel.get('preset'):
-                    m3u8_data += ' tvg-chno="{preset}"'.format(**channel)
-                if channel.get('group'):
-                    m3u8_data += ' group-title="{group}"'.format(**channel)
-                if channel.get('radio'):
-                    m3u8_data += ' radio="true"'
-                m3u8_data += ',{name}\n{stream}\n\n'.format(**channel)
-            fdesc.write(m3u8_data.encode('utf-8'))
+            for addon in channels:
+                m3u8_data += '## {addon_name}\n'.format(**addon)
+                for channel in addon['channels']:
+                    m3u8_data += '#EXTINF:-1 tvg-name="{name}"'.format(**channel)
+                    if channel.get('id'):
+                        m3u8_data += ' tvg-id="{id}"'.format(**channel)
+                    if channel.get('logo'):
+                        m3u8_data += ' tvg-logo="{logo}"'.format(**channel)
+                    if channel.get('preset'):
+                        m3u8_data += ' tvg-chno="{preset}"'.format(**channel)
+                    if channel.get('group'):
+                        m3u8_data += ' group-title="{group}"'.format(**channel)
+                    if channel.get('radio'):
+                        m3u8_data += ' radio="true"'
+                    m3u8_data += ',{name}\n{stream}\n\n'.format(**channel)
+                fdesc.write(m3u8_data.encode('utf-8'))
 
         # Move new file to the right place
         if os.path.isfile(playlist_path):

--- a/tests/mocks/plugin.video.example.two/addon.xml
+++ b/tests/mocks/plugin.video.example.two/addon.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<addon id="plugin.video.example.two" name="Example IPTV Addon Two" version="2.0.0" provider-name="IPTV Manager">
+    <extension point="xbmc.python.pluginsource" library="plugin.py">
+        <provides>video</provides>
+    </extension>
+</addon>

--- a/tests/mocks/plugin.video.example.two/plugin.py
+++ b/tests/mocks/plugin.video.example.two/plugin.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+""" This is a fake addon """
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+import sys
+
+try:  # Python 3
+    from urllib.parse import parse_qsl, urlparse
+except ImportError:  # Python 2
+    from urlparse import parse_qsl, urlparse
+
+logging.basicConfig(level=logging.DEBUG)
+_LOGGER = logging.getLogger()
+
+
+class IPTVManager:
+    """Interface to IPTV Manager"""
+
+    def __init__(self, port):
+        """Initialize IPTV Manager object"""
+        self.port = port
+
+    def via_socket(func):  # pylint: disable=no-self-argument
+        """Send the output of the wrapped function to socket"""
+
+        def send(self):
+            """Decorator to send over a socket"""
+            import json
+            import socket
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.connect(('127.0.0.1', self.port))
+            try:
+                sock.send(json.dumps(func()).encode())
+            finally:
+                sock.close()
+
+        return send
+
+    @via_socket
+    def send_channels():  # pylint: disable=no-method-argument
+        """Return JSON-M3U formatted information to IPTV Manager"""
+        streams = [
+            dict(
+                id='channel1.com',
+                name='Channel 1',
+                preset=1,
+                stream='plugin://plugin.video.example.two/play/1',
+                logo='https://example.com/channel1.png',
+                vod='plugin://plugin.video.example.two/play/airdate/{date}'
+            ),
+        ]
+        return dict(version=1, streams=streams)
+
+    @via_socket
+    def send_epg():  # pylint: disable=no-method-argument
+        """Return JSONTV formatted information to IPTV Manager"""
+        epg = {}
+        return dict(version=1, epg=epg)
+
+
+if __name__ == "__main__":
+
+    if len(sys.argv) <= 1:
+        print('ERROR: Missing URL as first parameter')
+        exit(1)
+
+    # Parse routing
+    url_parts = urlparse(sys.argv[1])
+    route = url_parts.path
+    query = dict(parse_qsl(url_parts.query))
+
+    if route == '/iptv/channels':
+        IPTVManager(int(query['port'])).send_channels()
+        exit()
+
+    if route == '/iptv/epg':
+        IPTVManager(int(query['port'])).send_epg()
+        exit()
+
+    if route.startswith('/play/airdate'):
+        _LOGGER.info('Starting playback of program with route %s and query %s', route, query)
+
+        # Touch a file so we can detect that we ended up here correctly
+        open('/tmp/playback-started.txt', 'a').close()
+        exit()
+
+    _LOGGER.error('Unknown route %s with query %s', route, query)
+    exit(1)

--- a/tests/mocks/plugin.video.example.two/resources/settings.xml
+++ b/tests/mocks/plugin.video.example.two/resources/settings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<settings>
+    <setting id="iptv.enabled" default="true" visible="false"/>
+    <setting id="iptv.channels_uri" default="plugin://plugin.video.example.two/iptv/channels" visible="false"/>
+</settings>

--- a/tests/mocks/plugin.video.example/plugin.py
+++ b/tests/mocks/plugin.video.example/plugin.py
@@ -14,7 +14,7 @@ try:  # Python 3
 except ImportError:  # Python 2
     from urlparse import parse_qsl, urlparse
 
-logging.basicConfig()
+logging.basicConfig(level=logging.DEBUG)
 _LOGGER = logging.getLogger()
 
 
@@ -51,6 +51,7 @@ class IPTVManager:
                 preset=1,
                 stream='plugin://plugin.video.example/play/1',
                 logo='https://example.com/channel1.png',
+                vod='plugin://plugin.video.example/play/airdate/{date}'
             ),
             dict(
                 id='channel2.com',
@@ -152,3 +153,13 @@ if __name__ == "__main__":
     if route == '/iptv/epg':
         IPTVManager(int(query['port'])).send_epg()
         exit()
+
+    if route.startswith('/play/airdate'):
+        _LOGGER.info('Starting playback of program with route %s and query %s', route, query)
+
+        # Touch a file so we can detect that we ended up here correctly
+        open('/tmp/playback-started.txt', 'a').close()
+        exit()
+
+    _LOGGER.error('Unknown route %s with query %s', route, query)
+    exit(1)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,12 +6,18 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+import time
 import unittest
+from xml.etree import ElementTree as etree
 
-from lxml import etree
+from mock import patch
+
+import xbmc
 
 from resources.lib.modules.addon import Addon
+from resources.lib.modules.contextmenu import ContextMenu
 from tests.xbmc import to_unicode
+from tests.xbmcgui import ListItem
 
 
 class IntegrationTest(unittest.TestCase):
@@ -28,7 +34,8 @@ class IntegrationTest(unittest.TestCase):
                 os.unlink(path)
 
         # Do the refresh
-        Addon.refresh(True)
+        with patch('xbmcgui.DialogProgress.iscanceled', return_value=False):
+            Addon.refresh(True)
 
         # Check that the files now exist
         for path in [m3u_path, epg_path]:
@@ -46,6 +53,53 @@ class IntegrationTest(unittest.TestCase):
         xml = etree.parse(epg_path)
         self.assertIsNotNone(xml.find('./channel[@id="channel1.com"]'))
         self.assertIsNotNone(xml.find('./channel[@id="één.be"]'))
+
+        # Now, try playing something from the Guide
+        import sys
+        sys.listitem = ListItem(path='pvr://guide/0006/2020-05-23 11:35:00.epg')
+        xbmc.INFO_LABELS.update({
+            'ListItem.ChannelName': 'Channel 1',
+            'ListItem.ChannelNumberLabel': 9,
+            'ListItem.Date': '22-05-2020 18:15',
+            'ListItem.EndTime': '19:15',
+            'ListItem.Duration': '01:00:00',
+            'ListItem.Title': 'Example Show',
+            'ListItem.FolderPath': 'pvr://guide/0006/2020-05-23 11:35:00.epg',
+        })
+
+        # Get the current selected EPG item
+        program = ContextMenu.get_selection()
+        self.assertTrue(program)
+        self.assertEqual(program.get('duration'), 3600)
+        self.assertEqual(program.get('channel'), 'Channel 1')
+
+        # Make sure we can detect that playback has started
+        if os.path.exists('/tmp/playback-started.txt'):
+            os.unlink('/tmp/playback-started.txt')
+
+        with patch('xbmcgui.Dialog.select', return_value=0):
+            # Try to play it
+            ContextMenu.play(program)
+
+        # Check that something has played
+        self.assertTrue(self._wait_for_file('/tmp/playback-started.txt'))
+
+        # Now, try playing something from the Guide but we moved our mouse...
+        sys.listitem = ListItem(path='pvr://guide/0012/2020-05-24 12:00:00.epg')
+
+        # Get the current selected EPG item, but the selected item is wrong.
+        program = ContextMenu.get_selection()
+        self.assertIsNone(program)
+
+    @staticmethod
+    def _wait_for_file(filename, timeout=10):
+        """ Wait until a file appears on the filesystem. """
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if os.path.exists(filename):
+                return True
+            time.sleep(.1)
+        return False
 
 
 if __name__ == '__main__':

--- a/tests/userdata/addon_settings.json
+++ b/tests/userdata/addon_settings.json
@@ -8,5 +8,9 @@
     "iptv.enabled": "true",
     "iptv.channels_uri": "plugin://plugin.video.example/iptv/channels",
     "iptv.epg_uri": "plugin://plugin.video.example/iptv/epg"
+  },
+  "plugin.video.example.two": {
+    "iptv.enabled": "true",
+    "iptv.channels_uri": "plugin://plugin.video.example.two/iptv/channels"
   }
 }

--- a/tests/xbmc.py
+++ b/tests/xbmc.py
@@ -39,7 +39,7 @@ INFO_LABELS = {
 
 REGIONS = {
     'datelong': '%A, %e %B %Y',
-    'dateshort': '%Y-%m-%d',
+    'dateshort': '%d-%m-%Y',
 }
 
 GLOBAL_SETTINGS = global_settings()

--- a/tests/xbmc.py
+++ b/tests/xbmc.py
@@ -167,7 +167,7 @@ def executebuiltin(function):
     import re
     try:
         command, params = re.search(r'([A-Za-z]+)\(([^\)]+)\)', function).groups()
-        if command == 'RunPlugin':
+        if command == 'RunPlugin' or command == 'PlayMedia':
             addon, route = re.search(r'plugin://([^/]+)(.*)', params).groups()
             if addon:
                 import subprocess
@@ -194,8 +194,7 @@ def executeJSONRPC(jsonrpccommand):
     if command.get('method') == 'Textures.RemoveTexture':
         return json.dumps(dict(id=1, jsonrpc='2.0', result="OK"))
     if command.get('method') == 'Addons.GetAddons':
-        # TODO: generate a list of addons based on the folders in tests/mocks
-        return json.dumps(dict(id=1, jsonrpc='2.0', result=dict(addons=[dict(addonid='plugin.video.example')])))
+        return json.dumps(dict(id=1, jsonrpc='2.0', result=dict(addons=[dict(addonid=addon) for addon in os.listdir('tests/mocks')])))
     log("executeJSONRPC does not implement method '{method}'".format(**command), 'Error')
     return json.dumps(dict(error=dict(code=-1, message='Not implemented'), id=1, jsonrpc='2.0'))
 

--- a/tests/xbmc.py
+++ b/tests/xbmc.py
@@ -167,7 +167,7 @@ def executebuiltin(function):
     import re
     try:
         command, params = re.search(r'([A-Za-z]+)\(([^\)]+)\)', function).groups()
-        if command == 'RunPlugin' or command == 'PlayMedia':
+        if command in ['RunPlugin', 'PlayMedia']:
             addon, route = re.search(r'plugin://([^/]+)(.*)', params).groups()
             if addon:
                 import subprocess

--- a/tests/xbmcextra.py
+++ b/tests/xbmcextra.py
@@ -175,5 +175,5 @@ def import_language(language):
     return podb
 
 
-ADDON_INFO = read_addon_xml('addon.xml')
-ADDON_ID = next(iter(list(ADDON_INFO.values()))).get('id')
+ADDON_INFO = next(iter(list(read_addon_xml('addon.xml').values())))
+ADDON_ID = ADDON_INFO.get('id')

--- a/tests/xbmcgui.py
+++ b/tests/xbmcgui.py
@@ -9,6 +9,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import sys
 from xbmcextra import kodi_to_ansi
 
+from tests.xbmc import VideoInfoTag
+
 
 class Control:
     """A reimplementation of the xbmcgui Control class"""
@@ -63,12 +65,10 @@ class Dialog:
         """A stub implementation for the xbmcgui Dialog class info() method"""
 
     @staticmethod
-    def select(heading, opt_list, autoclose=0, preselect=None, useDetails=False):
+    def select(heading, list, autoclose=0, preselect=-1, useDetails=False):  # pylint: disable=redefined-builtin
         """A stub implementation for the xbmcgui Dialog class select() method"""
-        if preselect is None:
-            preselect = []
         heading = kodi_to_ansi(heading)
-        print('\033[37;44;1mSELECT:\033[35;49;1m [%s] \033[37;1m%s\033[39;0m' % (heading, ', '.join(opt_list)))
+        print('\033[37;44;1mSELECT:\033[35;49;1m [%s] \033[37;1m%s\033[39;0m' % (heading, ', '.join(list)))
         return -1
 
     @staticmethod
@@ -266,6 +266,41 @@ class ListItem:
         """A stub implementation for the xbmcgui ListItem class setUniqueIDs() method"""
         return
 
+    def getLabel(self):
+        """A stub implementation for the xbmcgui ListItem class getLabel() method"""
+        return self.label
+
+    def getLabel2(self):
+        """A stub implementation for the xbmcgui ListItem class getLabel2() method"""
+        return self.label2
+
+    def getPath(self):
+        """A stub implementation for the xbmcgui ListItem class getPath() method"""
+        return self.path
+
+    def getfilename(self):
+        """A stub implementation for the xbmcgui ListItem class getfilename() method"""
+        return self.path
+
+    @staticmethod
+    def getArt(key):
+        """A stub implementation for the xbmcgui ListItem class getArt() method"""
+        return {}
+
+    @staticmethod
+    def isSelected():
+        """A stub implementation for the xbmcgui ListItem class isSelected() method"""
+        return True
+
+    @staticmethod
+    def getProperty(key):
+        """A stub implementation for the xbmcgui ListItem class getProperty() method"""
+        return None
+
+    @staticmethod
+    def getVideoInfoTag():
+        """A stub implementation for the xbmcgui ListItem class getVideoInfoTag() method"""
+        return VideoInfoTag()
 
 class Window:
     """A reimplementation of the xbmcgui Window"""


### PR DESCRIPTION
This PR allows the user to play Video On Demand content from the Kodi PVR Guide.

This requires the channel json to include a `vod` field, with an URI that we can use with `PlayMedia` to play a program based on the aired date.

This is the only supported way in Kodi Leia, for Matrix, more fancy stuff is possible, but that's for later.

This is implemented in the following PR's:
* https://github.com/add-ons/plugin.video.vtm.go/pull/181
* https://github.com/add-ons/plugin.video.vrt.nu/pull/760
* https://github.com/add-ons/plugin.video.viervijfzes/pull/29

Partially implements #1 