### PR TITLE
Implement genre

### DIFF
--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -54,7 +54,6 @@ msgid "The EPG data is not up to date. Do you want to refresh the EPG now?"
 msgstr "De EPG is niet up to date. Wil je deze nu vernieuwen?"
 
 
-
 ### SETTINGS
 msgctxt "#30800"
 msgid "Channels"

--- a/resources/lib/modules/iptvsimple.py
+++ b/resources/lib/modules/iptvsimple.py
@@ -199,6 +199,10 @@ class IptvSimple:
                         program += ' <date>{date}</date>\n'.format(
                             date=cls._xml_encode(item.get('date')))
 
+                    if item.get('genre'):
+                        program += ' <category>{genre}</category>\n'.format(
+                            genre=cls._xml_encode(item.get('genre')))
+
                     program += '</programme>\n'
 
                     fdesc.write(program.encode('utf-8'))

--- a/tests/mocks/plugin.video.example/plugin.py
+++ b/tests/mocks/plugin.video.example/plugin.py
@@ -91,6 +91,7 @@ class IPTVManager:
                     title='This is a show with an & ampersant.',
                     description='This is the description of the show € 4 + 4 > 6',
                     subtitle='Pilot episode',
+                    genre='Quiz',
                     episode='S01E01',
                     image='https://example.com/image.png',
                     date='1987-06-15',


### PR DESCRIPTION
This PR implements `genre` in the EPG. The sting will be passed as it is received from the Add-on. There is no color coding done yet.

Related PR's:
* https://github.com/add-ons/plugin.video.viervijfzes/pull/31
* https://github.com/add-ons/plugin.video.vtm.go/pull/186

Fixes #30 