### PR TITLE
Support start and stop timestamps in vod

### DIFF
--- a/resources/lib/modules/contextmenu.py
+++ b/resources/lib/modules/contextmenu.py
@@ -8,7 +8,7 @@ import logging
 import os
 import sys
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from resources.lib import kodiutils
 
@@ -67,6 +67,13 @@ class ContextMenu:
         format_params = {}
         if '{date}' in uri:
             format_params.update({'date': program.get('start').isoformat()})
+
+        if '{start}' in uri:
+            format_params.update({'start': program.get('start').isoformat()})
+
+        if '{stop}' in uri:
+            stop = program.get('start') + timedelta(seconds=program.get('duration'))
+            format_params.update({'stop': stop.isoformat()})
 
         if '{duration}' in uri:
             format_params.update({'duration': program.get('duration')})


### PR DESCRIPTION
This extends the `vod` attribute  in JSON-STREAMS format with `start` and `stop` timestamps to fully support the VRT NU airdate api:
`plugin://plugin.video.vrt.nu/play/airdate/<channel>/<start>/<stop>`
This should help to solve https://github.com/add-ons/service.iptv.manager/issues/29

The wiki should be updated accordingly: https://github.com/add-ons/service.iptv.manager/wiki/JSON-STREAMS-format