### PR TITLE
Use direct URI to play programs from the EPG in Kodi 18

### DIFF
--- a/resources/lib/functions.py
+++ b/resources/lib/functions.py
@@ -36,11 +36,18 @@ def refresh():
 
 
 def play_from_contextmenu():
-    """Play an item from the Context Menu"""
-    # Fetch selection from Kodi
-    program = ContextMenu.get_selection()
-    if program:
-        ContextMenu.play(program)
+    """Play an item from the Context Menu in Kodi 18"""
+    # Use the direct uri if we have any
+    stream = ContextMenu.get_direct_uri()
+    if stream:
+        kodiutils.execute_builtin('PlayMedia', stream)
+        return
+
+    # Construct an uri based on the timestamp of the selection
+    stream = ContextMenu.get_uri_by_timestamp()
+    if stream:
+        kodiutils.execute_builtin('PlayMedia', stream)
+        return
 
 
 def open_settings():

--- a/resources/lib/functions.py
+++ b/resources/lib/functions.py
@@ -37,15 +37,17 @@ def refresh():
 
 def play_from_contextmenu():
     """Play an item from the Context Menu in Kodi 18"""
-    # Use the direct uri if we have any
+    # Use the direct URI if we have any
     stream = ContextMenu.get_direct_uri()
     if stream:
+        _LOGGER.debug('Playing using direct URI: %s', stream)
         kodiutils.execute_builtin('PlayMedia', stream)
         return
 
-    # Construct an uri based on the timestamp of the selection
+    # Construct an URI based on the timestamp of the selection
     stream = ContextMenu.get_uri_by_timestamp()
     if stream:
+        _LOGGER.debug('Playing using generated URI: %s', stream)
         kodiutils.execute_builtin('PlayMedia', stream)
         return
 

--- a/resources/lib/modules/contextmenu.py
+++ b/resources/lib/modules/contextmenu.py
@@ -28,7 +28,7 @@ class ContextMenu:
     def get_direct_uri():
         """Retrieve a direct URI from the selected ListItem."""
         # We use a clever way / ugly hack (pick your choice) to hide the direct stream in Kodi 18.
-        # Title [COLOR green][B]•[/B][/COLOR][CR][COLOR vod="plugin://plugin.video.example/play/whatever"][/COLOR]
+        # Title [COLOR green]•[/COLOR][COLOR vod="plugin://plugin.video.example/play/whatever"][/COLOR]
         label = sys.listitem.getLabel()  # pylint: disable=no-member
         stream = re.search(r'\[COLOR vod="([^"]+)"\]', label)
         return stream.group(1) if stream else None

--- a/resources/lib/modules/iptvsimple.py
+++ b/resources/lib/modules/iptvsimple.py
@@ -171,7 +171,7 @@ class IptvSimple:
                         # We also use a clever way to hide the stream in the label so
                         # Kodi 18 can access the direct stream
                         title = '%s [COLOR green][B]•[/B][/COLOR][CR][COLOR vod="%s"][/COLOR]' % (
-                            cls._xml_encode(title), cls._xml_encode(item.get('stream'))
+                            title, item.get('stream')
                         )
 
                     program = '<programme start="{start}" stop="{stop}" channel="{channel}"{vod}>\n'.format(

--- a/resources/lib/modules/iptvsimple.py
+++ b/resources/lib/modules/iptvsimple.py
@@ -163,10 +163,10 @@ class IptvSimple:
                 for item in epg[key]:
                     start = dateutil.parser.parse(item.get('start')).strftime('%Y%m%d%H%M%S %z')
                     stop = dateutil.parser.parse(item.get('stop')).strftime('%Y%m%d%H%M%S %z')
-                    title = item.get('title')
+                    title = item.get('title', '')
 
                     # Add an icon ourselves in Kodi 18
-                    if title and item.get('stream') and kodiutils.kodi_version_major() < 19:
+                    if kodiutils.kodi_version_major() < 19 and item.get('stream'):
                         # We use a clever way to hide the direct URI in the label so Kodi 18 can access the it
                         title = '%s [COLOR green]•[/COLOR][COLOR vod="%s"][/COLOR]' % (
                             title, item.get('stream')

--- a/resources/lib/modules/iptvsimple.py
+++ b/resources/lib/modules/iptvsimple.py
@@ -167,10 +167,8 @@ class IptvSimple:
 
                     # Add an icon ourselves in Kodi 18
                     if title and item.get('stream') and kodiutils.kodi_version_major() < 19:
-                        # Add [CR] to fix a bug that causes the [/B] to be visible.
-                        # We also use a clever way to hide the stream in the label so
-                        # Kodi 18 can access the direct stream
-                        title = '%s [COLOR green][B]•[/B][/COLOR][CR][COLOR vod="%s"][/COLOR]' % (
+                        # We use a clever way to hide the direct URI in the label so Kodi 18 can access the it
+                        title = '%s [COLOR green]•[/COLOR][COLOR vod="%s"][/COLOR]' % (
                             title, item.get('stream')
                         )
 

--- a/resources/lib/modules/iptvsimple.py
+++ b/resources/lib/modules/iptvsimple.py
@@ -167,8 +167,12 @@ class IptvSimple:
 
                     # Add an icon ourselves in Kodi 18
                     if title and item.get('stream') and kodiutils.kodi_version_major() < 19:
-                        # Add [CR] to fix a bug that causes the [/B] to be visible
-                        title = title + ' [COLOR green][B]•[/B][/COLOR][CR]'
+                        # Add [CR] to fix a bug that causes the [/B] to be visible.
+                        # We also use a clever way to hide the stream in the label so
+                        # Kodi 18 can access the direct stream
+                        title = '%s [COLOR green][B]•[/B][/COLOR][CR][COLOR vod="%s"][/COLOR]' % (
+                            cls._xml_encode(title), cls._xml_encode(item.get('stream'))
+                        )
 
                     program = '<programme start="{start}" stop="{stop}" channel="{channel}"{vod}>\n'.format(
                         start=start,

--- a/tests/mocks/plugin.video.example/plugin.py
+++ b/tests/mocks/plugin.video.example/plugin.py
@@ -51,7 +51,7 @@ class IPTVManager:
                 preset=1,
                 stream='plugin://plugin.video.example/play/1',
                 logo='https://example.com/channel1.png',
-                vod='plugin://plugin.video.example/play/airdate/{date}'
+                vod='plugin://plugin.video.example/play/airdate/{start}/{stop}/{duration}'
             ),
             dict(
                 id='channel2.com',

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -68,10 +68,10 @@ class IntegrationTest(unittest.TestCase):
         })
 
         # Get the current selected EPG item
-        program = ContextMenu.get_selection()
-        self.assertTrue(program)
-        self.assertEqual(program.get('duration'), 3600)
-        self.assertEqual(program.get('channel'), 'Channel 1')
+        selection = ContextMenu._get_selection()  # pylint: disable=protected-access
+        self.assertTrue(selection)
+        self.assertEqual(selection.get('duration'), 3600)
+        self.assertEqual(selection.get('channel'), 'Channel 1')
 
         # Make sure we can detect that playback has started
         if os.path.exists('/tmp/playback-started.txt'):
@@ -79,7 +79,8 @@ class IntegrationTest(unittest.TestCase):
 
         with patch('xbmcgui.Dialog.select', return_value=0):
             # Try to play it
-            ContextMenu.play(program)
+            from resources.lib.functions import play_from_contextmenu
+            play_from_contextmenu()
 
         # Check that something has played
         self.assertTrue(self._wait_for_file('/tmp/playback-started.txt'))
@@ -88,8 +89,8 @@ class IntegrationTest(unittest.TestCase):
         sys.listitem = ListItem(path='pvr://guide/0012/2020-05-24 12:00:00.epg')
 
         # Get the current selected EPG item, but the selected item is wrong.
-        program = ContextMenu.get_selection()
-        self.assertIsNone(program)
+        selection = ContextMenu._get_selection()  # pylint: disable=protected-access
+        self.assertIsNone(selection)
 
     @staticmethod
     def _wait_for_file(filename, timeout=10):


### PR DESCRIPTION
This is an attempt to solve issue #29 and also make the experience in Kodi 18 better. It's also a huge hack.

* Fixes the issue with `sys.listitem` that isn't the same as `xbmc.getInfoLabel(ListItem.xxx)` since we only use the `sys.listitem.getLabel()`.
* Faster playback (since we don't need to do an EPG lookup anymore).
* Seems to work fine in the skins I've tested (Arctic Zaphyr 2 & Estuary).
* Much simpler code, no lookups needed by channel.

@mediaminister @dagwieers @MarcelRoozekrans 
