### PR TITLE
Support more than one genre for an episode

### DIFF
--- a/resources/lib/modules/iptvsimple.py
+++ b/resources/lib/modules/iptvsimple.py
@@ -202,8 +202,13 @@ class IptvSimple:
                             date=cls._xml_encode(item.get('date')))
 
                     if item.get('genre'):
-                        program += ' <category>{genre}</category>\n'.format(
-                            genre=cls._xml_encode(item.get('genre')))
+                        if isinstance(item.get('genre'), list):
+                            for genre in item.get('genre'):
+                                program += ' <category>{genre}</category>\n'.format(
+                                    genre=cls._xml_encode(genre))
+                        else:
+                            program += ' <category>{genre}</category>\n'.format(
+                                genre=cls._xml_encode(item.get('genre')))
 
                     program += '</programme>\n'
 


### PR DESCRIPTION
This supports more than one genre in the XMLTV output.

VRT NU can have more than one category for a tv show episode or a movie.