### PR TITLE
Don't throw an error when no addons are installed

### DIFF
--- a/resources/lib/modules/addon.py
+++ b/resources/lib/modules/addon.py
@@ -110,7 +110,7 @@ class Addon:
                                    params={'installed': True, 'enabled': True, 'type': 'xbmc.python.pluginsource'})
 
         addons = []
-        for row in result['result']['addons']:
+        for row in result['result'].get('addons', []):
             addon = kodiutils.get_addon(row['addonid'])
 
             # Check if add-on supports IPTV Manager


### PR DESCRIPTION
When no addon is installed, the `addons` key is missing in the JSON RPC response.

Fixes #36 