### PR TITLE
Allow passing credits with the EPG data

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -9,11 +9,6 @@ disable=
     raise-missing-from,  # This does not work on Python 2.7, remove later
     super-with-arguments,
     too-few-public-methods,
-    too-many-arguments,
     too-many-branches,
-    too-many-function-args,
-    too-many-instance-attributes,
-    too-many-locals,
-    too-many-public-methods,
-    too-many-return-statements,
 max-line-length=160
+max-statements=70

--- a/tests/xbmc.py
+++ b/tests/xbmc.py
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 """This file implements the Kodi xbmc module, either using stubs or alternative functionality"""
 
-# pylint: disable=invalid-name,no-self-use,unused-argument
+# pylint: disable=invalid-name,no-self-use,unused-argument,too-many-return-statements
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 

--- a/tests/xbmcgui.py
+++ b/tests/xbmcgui.py
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 """This file implements the Kodi xbmcgui module, either using stubs or alternative functionality"""
 
-# pylint: disable=invalid-name,super-on-old-class,too-many-arguments,unused-argument,useless-super-delegation
+# pylint: disable=invalid-name,super-on-old-class,too-many-arguments,unused-argument,useless-super-delegation,too-few-public-methods
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 import sys

--- a/tests/xbmcvfs.py
+++ b/tests/xbmcvfs.py
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 """This file implements the Kodi xbmcvfs module, either using stubs or alternative functionality"""
 
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,too-few-public-methods
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 import os


### PR DESCRIPTION
## Allow to pass credits to the EPG data

An optional list of credits can be supplied for a program. A credit is an object with the property `type` that can be `actor`, `director`, `writer`, `adapter`, `producer`, `composer`, `editor`, `presenter`, `commentator` or `guest`, and a property `name` that contains the name of the person. For the type `actor`, an optional property `role` can be added to give the name of the character that is played.

  Examples:
  * `{"type": "director", "name": "David Benioff"}`
  * `{"type": "writer", "name": "George R.R. Martin"}`
  * `{"type": "actor", "name": "Kit Harington", "role": "John Snow"}`

## Notes
* The types are based on the values that xmltv supports and seem like a good list of possible items. It also closely matched the different types I saw in the API of TV Vlaanderen.
* IPTV Simple only supports  `director`, `writer` and `actor`, so we have to make a mapping when writing the EPG.
* Also, when a parsing error occurs, we log it and continue with the next program instead of just stopping the processing.