### PR TITLE
Rollback pvr.iptvsimple to 3.8.8

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -3,7 +3,7 @@
     <requires>
         <import addon="xbmc.python" version="2.26.0"/>
         <import addon="script.module.dateutil" version="2.6.0"/>
-        <import addon="pvr.iptvsimple" version="3.9.8"/>
+        <import addon="pvr.iptvsimple" version="3.8.8"/>
     </requires>
     <!-- This is needed to get an add-on icon -->
     <extension point="xbmc.python.script" library="default.py">


### PR DESCRIPTION
Try to fix #52.

[Installed the iptv Simple package as documented](https://github.com/add-ons/service.iptv.manager/wiki/Frequent-questions#how-can-i-install-a-missing-pvriptvsimple-add-on):
`sudo apt install kodi-pvr-iptvsimple`

It installed `3.8.8-1~buster` which is not supported.