### PR TITLE
Add support for #KODIPROP

### DIFF
--- a/resources/lib/modules/iptvsimple.py
+++ b/resources/lib/modules/iptvsimple.py
@@ -122,8 +122,8 @@ class IptvSimple:
                     if channel.get('radio'):
                         m3u8_data += ' radio="true"'
                     m3u8_data += ' catchup="vod",{name}\n'.format(**channel)
-                    if channel.get('kodiprop'):
-                        for key, value in channel.get('kodiprop').items():
+                    if channel.get('kodiprops'):
+                        for key, value in channel.get('kodiprops').items():
                             m3u8_data += '#KODIPROP:{key}={value}\n'.format(key=key, value=value)
                     m3u8_data += '{stream}\n\n'.format(**channel)
 

--- a/resources/lib/modules/iptvsimple.py
+++ b/resources/lib/modules/iptvsimple.py
@@ -121,8 +121,11 @@ class IptvSimple:
                         m3u8_data += ' group-title="{group}"'.format(**channel)
                     if channel.get('radio'):
                         m3u8_data += ' radio="true"'
-
-                    m3u8_data += ' catchup="vod",{name}\n{stream}\n\n'.format(**channel)
+                    m3u8_data += ' catchup="vod",{name}\n'.format(**channel)
+                    if channel.get('kodiprop'):
+                        for key, value in channel.get('kodiprop').items():
+                            m3u8_data += '#KODIPROP:{key}={value}\n'.format(key=key, value=value)
+                    m3u8_data += '{stream}\n\n'.format(**channel)
 
             fdesc.write(m3u8_data.encode('utf-8'))
 

--- a/tests/home/addons/plugin.video.example/plugin.py
+++ b/tests/home/addons/plugin.video.example/plugin.py
@@ -51,6 +51,10 @@ class IPTVManager:
                 preset=1,
                 stream='plugin://plugin.video.example/play/1',
                 logo='https://example.com/channel1.png',
+                kodiprop={
+                    'inputstream': 'inputstream.ffmpegdirect',
+                    'inputstream.ffmpegdirect.is_realtime_stream': 'true',
+                },
             ),
             dict(
                 id='channel2.com',

--- a/tests/home/addons/plugin.video.example/plugin.py
+++ b/tests/home/addons/plugin.video.example/plugin.py
@@ -54,6 +54,7 @@ class IPTVManager:
                 kodiprops={
                     'inputstream': 'inputstream.ffmpegdirect',
                     'inputstream.ffmpegdirect.is_realtime_stream': 'true',
+                    'mimetype': 'video/mp2t',
                 },
             ),
             dict(

--- a/tests/home/addons/plugin.video.example/plugin.py
+++ b/tests/home/addons/plugin.video.example/plugin.py
@@ -51,7 +51,7 @@ class IPTVManager:
                 preset=1,
                 stream='plugin://plugin.video.example/play/1',
                 logo='https://example.com/channel1.png',
-                kodiprop={
+                kodiprops={
                     'inputstream': 'inputstream.ffmpegdirect',
                     'inputstream.ffmpegdirect.is_realtime_stream': 'true',
                 },

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -46,6 +46,7 @@ class IntegrationTest(unittest.TestCase):
             self.assertTrue('channel1.com' in data)
             self.assertTrue('radio1.com' in data)
             self.assertTrue('één.be' in data)
+            self.assertTrue('#KODIPROP:inputstream=inputstream.ffmpegdirect' in data)
 
         # Validate EPG
         xml = etree.parse(epg_path)


### PR DESCRIPTION
This PR adds support to put `#KODIPROP`-lines in the generated m3u playlist. These properties can be used to give additional information to Kodi on how to play an URI. The property is optional.

Example python JSON-STREAMS object:
```python
dict(
    id='channel1.com',
    name='Channel 1',
    preset=1,
    stream='plugin://plugin.video.example/play/1',
    logo='https://example.com/channel1.png',
    kodiprops={
        'inputstream': 'inputstream.ffmpegdirect',
        'inputstream.ffmpegdirect.is_realtime_stream': 'true',
        'mimetype': 'video/mp2t',
    }
)
```

This will generate the following m3u:
```m3u
#EXTINF:-1 tvg-name="Channel 1" tvg-id="channel1.com" tvg-logo="https://example.com/channel1.png" tvg-chno="1" group-title="Example IPTV Addon" catchup="vod",Channel 1
#KODIPROP:inputstream=inputstream.ffmpegdirect
#KODIPROP:inputstream.ffmpegdirect.is_realtime_stream=true
plugin://plugin.video.example/play/1
```