### PR TITLE
Fix empty space in start and stop fields when no timezone was specified

### DIFF
--- a/resources/lib/modules/iptvsimple.py
+++ b/resources/lib/modules/iptvsimple.py
@@ -174,8 +174,8 @@ class IptvSimple:
     def _construct_epg_program_xml(cls, item, channel):
         """ Generate the XML for the EPG of a program. """
         try:
-            start = dateutil.parser.parse(item.get('start')).strftime('%Y%m%d%H%M%S %z')
-            stop = dateutil.parser.parse(item.get('stop')).strftime('%Y%m%d%H%M%S %z')
+            start = dateutil.parser.parse(item.get('start')).strftime('%Y%m%d%H%M%S %z').rstrip()
+            stop = dateutil.parser.parse(item.get('stop')).strftime('%Y%m%d%H%M%S %z').rstrip()
             title = item.get('title', '')
 
             # Add an icon ourselves in Kodi 18

--- a/tests/home/addons/plugin.video.example.two/plugin.py
+++ b/tests/home/addons/plugin.video.example.two/plugin.py
@@ -3,9 +3,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
-import os
 import sys
-import tempfile
 
 import xbmc
 import xbmcplugin

--- a/tests/home/addons/plugin.video.example/plugin.py
+++ b/tests/home/addons/plugin.video.example/plugin.py
@@ -81,6 +81,7 @@ class IPTVManager:
     def send_epg():  # pylint: disable=no-method-argument
         """Return JSON-EPG formatted information to IPTV Manager"""
         now = datetime.datetime.now(tz=dateutil.tz.gettz('CET'))
+        now_notz = datetime.datetime.now()
 
         epg = {
             'channel1.com': [
@@ -107,17 +108,17 @@ class IPTVManager:
             ],
             'channel2.com': [
                 dict(
-                    start=now.isoformat(),
-                    stop=(now + datetime.timedelta(seconds=1800)).isoformat(),
-                    title='This is a show 3',
+                    start=now_notz.isoformat(),
+                    stop=(now_notz + datetime.timedelta(seconds=1800)).isoformat(),
+                    title='This is a show 3 (no timezone info)',
                     description='This is the description of the show 3',
                     image=None,
                     stream='plugin://plugin.video.example/play/something',
                 ),
                 dict(
-                    start=(now + datetime.timedelta(seconds=1800)).isoformat(),
-                    stop=(now + datetime.timedelta(seconds=3600)).isoformat(),
-                    title='This is a show 4',
+                    start=(now_notz + datetime.timedelta(seconds=1800)).isoformat(),
+                    stop=(now_notz + datetime.timedelta(seconds=3600)).isoformat(),
+                    title='This is a show 4 (no timezone info)',
                     description='This is the description of the show 4',
                     image=None,
                     stream='plugin://plugin.video.example/play/something',


### PR DESCRIPTION
This PR fixes a small issue that causes an empty space to be added to the `start` and `stop` dates in the XML when no timezone is specified in the ISO 8601 format of the EPG info.