### PR TITLE
Add support for resource:// logos

### DIFF
--- a/resources/lib/modules/addon.py
+++ b/resources/lib/modules/addon.py
@@ -159,11 +159,10 @@ class Addon:
                 continue
 
             # Fix logo path to be absolute
-            if channel.get('logo'):
-                if not channel.get('logo').startswith(('http://', 'https://', 'special://', '/')):
-                    channel['logo'] = os.path.join(self.addon_path, channel.get('logo'))
-            else:
+            if not channel.get('logo'):
                 channel['logo'] = kodiutils.addon_icon(self.addon_obj)
+            elif not channel.get('logo').startswith(('http://', 'https://', 'special://', 'resource://', '/')):
+                channel['logo'] = os.path.join(self.addon_path, channel.get('logo'))
 
             # Add add-on name as group
             if not channel.get('group'):


### PR DESCRIPTION
Since Catch-up TV & More makes use of logos from another resource add-in, we need to also support _resource://_ locations.

This ought to work as Catch-up TV & More was doing this in their M3U8 files before: https://github.com/Catch-up-TV-and-More/plugin.video.catchuptvandmore/commit/46bc1f3492cfb30d535ccaf5b63f30e3585f9b0d

cc @sy6sy2 