### PR TITLE
Make JSON-STREAMS group a list

### DIFF
--- a/resources/lib/modules/iptvsimple.py
+++ b/resources/lib/modules/iptvsimple.py
@@ -125,7 +125,7 @@ class IptvSimple:
                     if channel.get('preset'):
                         m3u8_data += ' tvg-chno="{preset}"'.format(**channel)
                     if channel.get('group'):
-                        m3u8_data += ' group-title="{group}"'.format(**channel)
+                        m3u8_data += ' group-title="{groups}"'.format(groups=';'.join(channel.get('group')))
                     if channel.get('radio'):
                         m3u8_data += ' radio="true"'
                     m3u8_data += ' catchup="vod",{name}\n'.format(**channel)

--- a/tests/home/addons/plugin.video.example/plugin.py
+++ b/tests/home/addons/plugin.video.example/plugin.py
@@ -68,6 +68,7 @@ class IPTVManager:
                 preset=901,
                 stream='plugin://plugin.video.example/play/901',
                 logo='https://example.com/radio1.png',
+                group='VRT',
                 radio=True,
             ),
             dict(
@@ -76,6 +77,7 @@ class IPTVManager:
                 preset=101,
                 stream='plugin://plugin.video.example/play/één',
                 logo='https://example.com/één.png',
+                group=['Belgium', 'VRT'],
             ),
         ]
         return dict(version=1, streams=streams)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,10 +6,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+import re
 import time
 import unittest
-import lxml.etree
 
+import lxml.etree
 import xbmc
 from mock import patch
 from xbmcgui import ListItem
@@ -50,12 +51,13 @@ class IntegrationTest(unittest.TestCase):
             self.assertTrue('#KODIPROP:inputstream=inputstream.ffmpegdirect' in data)
 
             # Check groups
-            self.assertRegex(data, r'#EXTINF:-1 .*?tvg-id="channel1.com".*?group-title="Example IPTV Addon"')
-            self.assertRegex(data, r'#EXTINF:-1 .*?tvg-id="één.be".*?group-title=".*?VRT.*?"')
-            self.assertRegex(data, r'#EXTINF:-1 .*?tvg-id="één.be".*?group-title=".*?Belgium.*?"')
-            self.assertRegex(data, r'#EXTINF:-1 .*?tvg-id="één.be".*?group-title=".*?Example IPTV Addon.*?"')
-            self.assertRegex(data, r'#EXTINF:-1 .*?tvg-id="radio1.com".*?group-title=".*?VRT.*?"')
-            self.assertRegex(data, r'#EXTINF:-1 .*?tvg-id="radio1.com".*?group-title=".*?Example IPTV Addon.*?"')
+            # self.assertRegex doesn't exists in Python 2.7, and self.assertRegexpMatches throws warnings in Python 3
+            self.assertTrue(re.search(r'#EXTINF:-1 .*?tvg-id="channel1.com".*?group-title="Example IPTV Addon"', data))
+            self.assertTrue(re.search(r'#EXTINF:-1 .*?tvg-id="één.be".*?group-title=".*?VRT.*?"', data))
+            self.assertTrue(re.search(r'#EXTINF:-1 .*?tvg-id="één.be".*?group-title=".*?Belgium.*?"', data))
+            self.assertTrue(re.search(r'#EXTINF:-1 .*?tvg-id="één.be".*?group-title=".*?Example IPTV Addon.*?"', data))
+            self.assertTrue(re.search(r'#EXTINF:-1 .*?tvg-id="radio1.com".*?group-title=".*?VRT.*?"', data))
+            self.assertTrue(re.search(r'#EXTINF:-1 .*?tvg-id="radio1.com".*?group-title=".*?Example IPTV Addon.*?"', data))
 
         # Validate EPG
         xml = lxml.etree.parse(epg_path)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -49,6 +49,14 @@ class IntegrationTest(unittest.TestCase):
             self.assertTrue('raw1.com' in data)
             self.assertTrue('#KODIPROP:inputstream=inputstream.ffmpegdirect' in data)
 
+            # Check groups
+            self.assertRegex(data, r'#EXTINF:-1 .*?tvg-id="channel1.com".*?group-title="Example IPTV Addon"')
+            self.assertRegex(data, r'#EXTINF:-1 .*?tvg-id="één.be".*?group-title=".*?VRT.*?"')
+            self.assertRegex(data, r'#EXTINF:-1 .*?tvg-id="één.be".*?group-title=".*?Belgium.*?"')
+            self.assertRegex(data, r'#EXTINF:-1 .*?tvg-id="één.be".*?group-title=".*?Example IPTV Addon.*?"')
+            self.assertRegex(data, r'#EXTINF:-1 .*?tvg-id="radio1.com".*?group-title=".*?VRT.*?"')
+            self.assertRegex(data, r'#EXTINF:-1 .*?tvg-id="radio1.com".*?group-title=".*?Example IPTV Addon.*?"')
+
         # Validate EPG
         xml = lxml.etree.parse(epg_path)
         validator = lxml.etree.DTD('tests/xmltv.dtd')


### PR DESCRIPTION
Just as the M3U8 standard allows multiple group names, JSON-STREAMS should accept a list of groups.

This relates to #76 