### PR TITLE
Fix for Configure IPTV automatically

### DIFF
--- a/resources/lib/modules/iptvsimple.py
+++ b/resources/lib/modules/iptvsimple.py
@@ -12,6 +12,8 @@ import dateutil.tz
 
 from resources.lib import kodiutils
 
+import xbmcvfs, glob, shutil
+
 _LOGGER = logging.getLogger(__name__)
 
 IPTV_SIMPLE_ID = 'pvr.iptvsimple'
@@ -64,6 +66,14 @@ class IptvSimple:
 
         # Activate IPTV Simple
         cls._activate()
+
+        # If iptv simple uses another name than settings.cml for the configuration file then copy the generated settings.xml to that other name
+        path = xbmcvfs.translatePath(addon.getAddonInfo('profile'))
+        settingsxml = path + 'settings.xml'
+        if os.path.isfile(settingsxml):
+          for f in glob.glob(path + "*.xml"):
+            if os.path.basename(f) != 'settings.xml':
+              shutil.copyfile(settingsxml, f)
 
         return True
 


### PR DESCRIPTION
Configure IPTV automatically creates a settings.xml file for IPTV Simple but IPTV Simple uses another name. This fix copies the generated settings.xml file to the other .xml files